### PR TITLE
Improve todo app with storage and editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-# codex-test-site
+# To-Do App
+
+This is a simple to-do application. It lets you add, edit and remove tasks.
+Tasks are persisted in your browser using `localStorage` so they remain after a refresh.
+
+## Running
+
+Open `index.html` in a browser.

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Simple To-Do App</title>
+    <title>Enhanced To-Do App</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -11,6 +11,7 @@
     <div id="todo-app">
         <input id="new-task" type="text" placeholder="Add a new task">
         <button id="add-task">Add</button>
+        <button id="clear-completed">Clear Completed</button>
         <ul id="task-list"></ul>
     </div>
     <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -1,30 +1,85 @@
-// Simple to-do app logic
+// Enhanced to-do app logic with persistence and editing
+const taskInput = document.getElementById('new-task');
+const addButton = document.getElementById('add-task');
+const clearButton = document.getElementById('clear-completed');
+const taskList = document.getElementById('task-list');
 
-document.getElementById('add-task').addEventListener('click', addTask);
-document.getElementById('new-task').addEventListener('keypress', function(e) {
-    if (e.key === 'Enter') {
-        addTask();
-    }
-});
+let tasks = [];
+
+function saveTasks() {
+    localStorage.setItem('tasks', JSON.stringify(tasks));
+}
+
+function loadTasks() {
+    tasks = JSON.parse(localStorage.getItem('tasks')) || [];
+}
+
+function renderTasks() {
+    taskList.innerHTML = '';
+    tasks.forEach((task, index) => {
+        const li = document.createElement('li');
+        li.className = 'task';
+        if (task.completed) li.classList.add('completed');
+
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.checked = task.completed;
+        checkbox.addEventListener('change', () => {
+            task.completed = checkbox.checked;
+            saveTasks();
+            renderTasks();
+        });
+
+        const span = document.createElement('span');
+        span.textContent = task.text;
+
+        const editBtn = document.createElement('button');
+        editBtn.textContent = 'Edit';
+        editBtn.addEventListener('click', () => {
+            const newText = prompt('Edit task', task.text);
+            if (newText !== null) {
+                task.text = newText.trim();
+                saveTasks();
+                renderTasks();
+            }
+        });
+
+        const removeBtn = document.createElement('button');
+        removeBtn.textContent = 'Remove';
+        removeBtn.addEventListener('click', () => {
+            tasks.splice(index, 1);
+            saveTasks();
+            renderTasks();
+        });
+
+        li.appendChild(checkbox);
+        li.appendChild(span);
+        li.appendChild(editBtn);
+        li.appendChild(removeBtn);
+        taskList.appendChild(li);
+    });
+}
 
 function addTask() {
-    const taskInput = document.getElementById('new-task');
-    const taskText = taskInput.value.trim();
-    if (!taskText) return;
-
-    const li = document.createElement('li');
-    li.className = 'task';
-    li.textContent = taskText;
-
-    const removeBtn = document.createElement('button');
-    removeBtn.textContent = 'Remove';
-    removeBtn.addEventListener('click', function() {
-        li.remove();
-    });
-
-    li.appendChild(removeBtn);
-    document.getElementById('task-list').appendChild(li);
-
+    const text = taskInput.value.trim();
+    if (!text) return;
+    tasks.push({ text, completed: false });
+    saveTasks();
+    renderTasks();
     taskInput.value = '';
     taskInput.focus();
 }
+
+addButton.addEventListener('click', addTask);
+taskInput.addEventListener('keypress', (e) => {
+    if (e.key === 'Enter') addTask();
+});
+
+clearButton.addEventListener('click', () => {
+    tasks = tasks.filter(task => !task.completed);
+    saveTasks();
+    renderTasks();
+});
+
+loadTasks();
+renderTasks();

--- a/style.css
+++ b/style.css
@@ -20,6 +20,15 @@ body {
     padding: 5px 0;
 }
 
+.completed span {
+    text-decoration: line-through;
+    color: #777;
+}
+
 .task button {
     margin-left: 10px;
+}
+
+#clear-completed {
+    margin-top: 10px;
 }


### PR DESCRIPTION
## Summary
- rewrite README
- add Clear Completed button in HTML
- support editing tasks and persistence with localStorage
- style completed tasks

## Testing
- `node -e "console.log('node works')"`


------
https://chatgpt.com/codex/tasks/task_e_683faad0e224832086e952ff205e4ef0